### PR TITLE
fix Storybook integration for Windows

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,7 +10,7 @@ module.exports = {
 
     const babelRule = config.module.rules.find(rule => rule.test.toString() === /\.(mjs|tsx?|jsx?)$/.toString())
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code
-    babelRule.exclude = [/node_modules\/(?!(gatsby)\/)/]
+    babelRule.exclude = [/node_modules[\\/](?!(gatsby)[\\/])/]
     // Add Emotion css prop support
     babelRule.use[0].options.presets.push(require.resolve('@emotion/babel-preset-css-prop'))
     // Remove static queries from components


### PR DESCRIPTION
Added support for two variations of slashes in `extends` regular expression.